### PR TITLE
update regex to include new orcid bioformat

### DIFF
--- a/src/main/java/org/monarchinitiative/hpoannotqc/annotations/HpoAnnotationEntry.java
+++ b/src/main/java/org/monarchinitiative/hpoannotqc/annotations/HpoAnnotationEntry.java
@@ -128,7 +128,7 @@ public class HpoAnnotationEntry {
   /**
    * regex for patterns such as HPO:skoehler[2018-09-22]
    */
-  private static final String biocurationRegex = "(\\w+:\\w+)\\[(\\d{4}-\\d{2}-\\d{2})]";
+  private static final String biocurationRegex = "\\w+:\\w+\\[\\d{4}-\\d{2}-\\d{2}]|ORCID:\\d{4}-\\d{4}-\\d{4}-\\d{4}";
   /**
    * The pattern that corresponds to {@link #biocurationRegex}.
    */


### PR DESCRIPTION
> Format changes were introduced to the small files thus breaking downstream hpoa.  (~3,000 annotations were lost)
> I suggest we refactor how the hpoa pipeline is working so that these things don't happen, for instance, using a schema package to produce both the small and big files so that if one changes we know the other will break
> There are barely any tests in this package as well which also smells like we could have bugs lurking about that we don't know about. Time for a refactor.