### PR TITLE
hotfix unintentional changes

### DIFF
--- a/src/main/java/org/monarchinitiative/hpoannotqc/cmd/SupplementalFilesCommand.java
+++ b/src/main/java/org/monarchinitiative/hpoannotqc/cmd/SupplementalFilesCommand.java
@@ -78,7 +78,7 @@ public class SupplementalFilesCommand implements Callable<Integer> {
             writer.newLine();
             hpoOntology.getTerms().stream().distinct().forEach(term -> {
                 final TermId phenotype = term.id();
-                Set<TermId> children = hpoOntology.graph().getChildren(phenotype);
+                Collection<TermId> children = hpoOntology.graph().extendWithDescendants(phenotype, true);
                 final Optional<String> phenotypeLabel = hpoOntology.getTermLabel(phenotype);
                 if(phenotypeLabel.isEmpty()) {
                     throw new RuntimeException(String.format("Can not find label for phenotype id %s.", phenotype));


### PR DESCRIPTION
The old OntologyTerms.childrenOf was poorly named and actually visited all descendants. With #65 we had a change here that used the new children api which strictly visits children. 

I've moved this to include descendants and also self as it was implicit in the old api. This will fix the phenotype to gene file changes that I should have caught before going live.